### PR TITLE
Fix thrusters running immediately when armed

### DIFF
--- a/src/surface/flight_control/flight_control/mavlink_control_node.py
+++ b/src/surface/flight_control/flight_control/mavlink_control_node.py
@@ -83,11 +83,10 @@ DPAD_UP = 16
 # L2 and R2 1 is not pressed and -1 is pressed
 LJOYX = 0
 LJOYY = 1
-L2PRESS_PERCENT = 2
-RJOYX = 3
-RJOYY = 4
+RJOYX = 2
+RJOYY = 3
+L2PRESS_PERCENT = 4
 R2PRESS_PERCENT = 5
-
 
 CONTROLLER_PROFILE_PARAM = 'controller_profile'
 


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
fixed the thrusters running immediately when armed because the joystick indexes were shifted.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #
